### PR TITLE
Edgecase handling for ObjectAssigner

### DIFF
--- a/com.cyan.playerobjectpool/UdonSharp/CyanPlayerObjectAssigner.cs
+++ b/com.cyan.playerobjectpool/UdonSharp/CyanPlayerObjectAssigner.cs
@@ -174,6 +174,11 @@ namespace Cyan.PlayerObjectPool
         [PublicAPI]
         public GameObject _GetPlayerPooledObjectById(int playerId)
         {
+            if (!_enabledAndInitialized)
+            {
+                return null;
+            }
+            
             int index = _objectPool._GetPlayerPoolIndexById(playerId);
 
             if (index == -1)


### PR DESCRIPTION
Fix for a error that would cause an error when a script tried to request a object before the script was initialized.